### PR TITLE
allow external SD card storage; cleanups

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/bash
 
+[ -n "$ping_ok" ] || if ping -c 1 google.com &>/dev/null; then ping_ok=true; else ping_ok=false; fi
+
 terminate() {
     killall -9 java &> /dev/null
     killall -9 dialog &> /dev/null
@@ -71,7 +73,7 @@ initialize() {
 }
 
 internet() {
-    if ! ping -c 1 google.com &> /dev/null; then
+    if ! "$ping_ok"; then
         "${header[@]}" --msgbox "Oops! No Internet Connection available.\n\nConnect to Internet and try again later." 12 45
         return 1
     fi

--- a/main.sh
+++ b/main.sh
@@ -21,7 +21,7 @@ setEnv() {
 }
 
 initialize() {
-    internalStorage="/storage/emulated/0"
+    : "${internalStorage:=/storage/emulated/0}"
     storagePath="$internalStorage/Revancify"
     [ ! -d "$storagePath" ] && mkdir -p "$storagePath"
     [ ! -d apps ] && mkdir -p apps

--- a/main.sh
+++ b/main.sh
@@ -537,7 +537,7 @@ fetchApk() {
             return 0
         fi
     else
-        rm -rf "apps/$appName"* &> /dev/null
+        rm -rf "$DATA/apps/$appName"* &> /dev/null
     fi
     downloadApp || return 1
 }
@@ -628,7 +628,7 @@ deleteComponents() {
             ;;
         2 )
             if "${header[@]}" --begin 2 0 --title '| Delete Apps |' --no-items --defaultno --yesno "Please confirm to delete all the downloaded and patched apps." -1 -1; then
-                rm -rf "apps"/*
+                rm -rf "$DATA/apps"/*
                 "${header[@]}" --msgbox "All Apps are successfully deleted !!" 12 45
             fi
             ;;

--- a/revancify
+++ b/revancify
@@ -167,7 +167,7 @@ if [ "$online" == true ]; then
 fi
 dialog --no-shadow --infobox "\n  █▀█ █▀▀ █░█ ▄▀█ █▄░█ █▀▀ █ █▀▀ █▄█\n  █▀▄ ██▄ ▀▄▀ █▀█ █░▀█ █▄▄ █ █▀░ ░█░  \n\nDeveloper    : decipher\nLast Updated : $(git log -1 --pretty='format:%cd' --date=format:'%b %d, %Y | %H:%M')\nOnline       : $online" 10 42
 cd "$DATA" >/dev/null 2>&1 || true
-bash "$repo/main.sh" "$root" "$online"
+bash $(case $- in (*x*) printf %s -x ;; esac) "$repo/main.sh" "$root" "$online"
 exitstatus=$?
 clear
 cd "$HOME" || :

--- a/revancify
+++ b/revancify
@@ -91,14 +91,14 @@ terminate() {
 trap terminate SIGTERM SIGINT SIGABRT
 
 checkdependencies() {
-    if [ -f "$DATA/aapt2" ] && bins=$(ls "$BIN") && grep -q java <<<"$bins" && grep -q wget <<<"$bins" && grep -q tput <<<"$bins" && grep -q dialog <<<"$bins" && grep -q pup <<<"$bins" && grep -q jq <<<"$bins" && ls "$BIN/revancify" >/dev/null 2>&1 && ls "$HOME/storage" >/dev/null 2>&1; then
+    if [ -f "$DATA/aapt2" ] && (for f in java wget tput dialog pup jq revancify; do [ -x "$BIN/$f" ] || exit 1; done) && [ -e "$HOME/storage" ]; then
         return 0
     else
         if ping -c 1 google.com >/dev/null 2>&1; then
-            installdependencies || (echo "Dependencies not installed !!" && exit 1)
+            installdependencies || { echo "Dependencies not installed !!" && exit 1; }
         else
             cp "$repo/revancify" "$BIN/revancify"
-            echo -e "Dependencies not installed !!\nRun again with internet connection."
+            printf 'Dependencies not installed !!\nRun again with internet connection.'
             exit 1
         fi
     fi

--- a/revancify
+++ b/revancify
@@ -2,8 +2,7 @@
 
 if ping -c 1 google.com &>/dev/null; then ping_ok=true; else ping_ok=false; fi; export ping_ok
 
-HOME=/data/data/com.termux/files/home
-BIN=/data/data/com.termux/files/usr/bin
+BIN=$PREFIX/bin
 
 repo="$HOME/Revancify"
 cp "$repo/revancify" "$BIN/revancify" >/dev/null 2>&1

--- a/revancify
+++ b/revancify
@@ -123,7 +123,7 @@ installdependencies() {
 checkrevancify() {
     if [ -d "$repo" ]; then
         cd "$repo" >/dev/null 2>&1 || true
-        rm -rf ./*cache*
+        rm -rf "$repo"/*cache*
         return 0
     else
         echo -e "\e[1;31mRevancify dir is not found !!"
@@ -174,6 +174,6 @@ if [ $exitstatus -eq 0 ]; then
     echo "Script exited !!"
 else
     echo "Script terminated !!"
-    rm -rf -- *cache >/dev/null 2>&1
+    rm -rf -- "$repo"/*cache >/dev/null 2>&1
 fi
 tput cnorm

--- a/revancify
+++ b/revancify
@@ -1,5 +1,7 @@
 #!/usr/bin/bash
 
+if ping -c 1 google.com &>/dev/null; then ping_ok=true; else ping_ok=false; fi; export ping_ok
+
 HOME=/data/data/com.termux/files/home
 BIN=/data/data/com.termux/files/usr/bin
 
@@ -52,7 +54,7 @@ do
                         shift
                         ;;
     "-r" | "--reinstall")
-                        if ping -c 1 google.com >/dev/null 2>&1; then
+                        if "$ping_ok"; then
                             rm -rf $DATA
                             cd "$repo"/.. && rm -rf "$repo" && git clone --depth=1 https://github.com/decipher3114/Revancify.git && "$repo/revancify" && exit
                         else
@@ -94,7 +96,7 @@ checkdependencies() {
     if [ -f "$DATA/aapt2" ] && (for f in java wget tput dialog pup jq revancify; do [ -x "$BIN/$f" ] || exit 1; done) && [ -e "$HOME/storage" ]; then
         return 0
     else
-        if ping -c 1 google.com >/dev/null 2>&1; then
+        if "$ping_ok"; then
             installdependencies || { echo "Dependencies not installed !!" && exit 1; }
         else
             cp "$repo/revancify" "$BIN/revancify"
@@ -155,7 +157,7 @@ tput civis
 dialog --no-shadow --infobox "\n  █▀█ █▀▀ █░█ ▄▀█ █▄░█ █▀▀ █ █▀▀ █▄█\n  █▀▄ ██▄ ▀▄▀ █▀█ █░▀█ █▄▄ █ █▀░ ░█░  \n\nDeveloper    : decipher\nLast Updated : Checking...\nOnline       : $online" 10 42
 
 if [ "$online" != false ]; then
-    ping -c 1 google.com >/dev/null 2>&1 && online=true || online=false
+    "$ping_ok" && online=true || online=false
 fi
 
 if [ "$online" == true ]; then


### PR DESCRIPTION
This PR allows revancify users to set the apk target folder, via
```
internalStorage=/storage/XXXX-XXXX ~/Revancify/revancify
```

It also cleans up some problematic code, though plenty of it remains. I'll point this out in separate GH issues.

If the authors are interested, this could be further developed (i.e. add a command-line switch, and update user-facing messages to reflect the actual storage location).