### PR TITLE
fix: Wrong Download file Patches and Integrations

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -86,7 +86,7 @@ fetchToolsAPI() {
     : >".${source}-data"
     [ "$FetchPreReleasedTools" == false ] && stableRelease="/latest" || stableRelease=""
     i=0 && for tool in "${tools[@]}"; do
-        curl -s --fail-early --connect-timeout 2 --max-time 5 "https://api.github.com/repos/${links[$i]}/releases$stableRelease" | jq -r --arg tool "$tool" 'if type == "array" then .[0] else . end | $tool+"Latest="+.tag_name, (.assets[] | if .content_type == "application/json" then "jsonUrl="+.browser_download_url, "jsonSize="+(.size|tostring) else $tool+"Url="+.browser_download_url, $tool+"Size="+(.size|tostring) end)' >>".${source}-data"
+        curl -s --fail-early --connect-timeout 2 --max-time 5 "https://api.github.com/repos/${links[$i]}/releases$stableRelease" | jq -r --arg tool "$tool" 'if type == "array" then .[0] else . end | $tool+"Latest="+.tag_name, (.assets[] | select(.content_type != "application/pgp-keys") | if .content_type == "application/json" then "jsonUrl="+.browser_download_url, "jsonSize="+(.size|tostring) else $tool+"Url="+.browser_download_url, $tool+"Size="+(.size|tostring) end)' >>".${source}-data"
         i=$(("$i" + 1))
     done
 


### PR DESCRIPTION
Fix wrong Download File Patches and Integrations who cause "java.util.zip.ZipException: zip END header not found" because wrong downloading file and fix that by ignoring application/pgp-keys 
![Screenshot_2024-03-03-15-15-16-535_com termux](https://github.com/decipher3114/Revancify/assets/32153003/cff64892-199f-4042-ad61-65cffa8d4b54)
![Screenshot_2024-03-03-15-15-01-306_com termux](https://github.com/decipher3114/Revancify/assets/32153003/e2f6c775-25e6-4af5-ad5a-e3c044954258)
