### PR TITLE
feat: add preference `IgnoreAppSizeCheck`

### DIFF
--- a/fetch_link.sh
+++ b/fetch_link.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-UserAgent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
+UserAgent="Mozilla/5.0 (Linux; Android 14; Pixel 8 Pro Build/AP1A.240505.005) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.6422.113 Mobile Safari/537.36"
 
 arch=$(getprop ro.product.cpu.abi)
 developer="$1"

--- a/fetch_versions.sh
+++ b/fetch_versions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-UserAgent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
+UserAgent="Mozilla/5.0 (Linux; Android 14; Pixel 8 Pro Build/AP1A.240505.005) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.6422.113 Mobile Safari/537.36"
 
 appName="$1"
 apkmirrorAppName="$2"

--- a/main.sh
+++ b/main.sh
@@ -30,7 +30,7 @@ initialize() {
     header=(dialog --backtitle "Revancify | [Arch: $arch, Root: $root]" --no-shadow)
     envFile=config.cfg
     [ ! -f "apps/.appSize" ] && : > "apps/.appSize"
-    userAgent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
+    userAgent="Mozilla/5.0 (Linux; Android 14; Pixel 8 Pro Build/AP1A.240505.005) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.6422.113 Mobile Safari/537.36"
 
     AutocheckToolsUpdate="" Riplibs="" LightTheme="" ShowConfirmPatchesMenu="" LaunchAppAfterMount="" AllowVersionDowngrade="" FetchPreReleasedTools="" IgnoreAppSizeCheck=""
     setEnv AutocheckToolsUpdate false init "$envFile"


### PR DESCRIPTION
This is a temporary workaround for the issue https://github.com/decipher3114/Revancify/issues/82

I think it would be better to temporarily disable size checking of downloaded APKs until the issue on APKMirror's side is resolved

Instead of using app size to check the integrity of downloaded apk, we need to find a better way