### PR TITLE
fix kitadai31 cli repo name

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -95,7 +95,7 @@
             "cli":
             {
                 "org": "kitadai31",
-                "repo": "rvcli"
+                "repo": "revanced-cli"
             },
             "patches":
             {
@@ -161,7 +161,7 @@
             "cli":
             {
                 "org": "kitadai31",
-                "repo": "rvcli"
+                "repo": "revanced-cli"
             },
             "patches":
             {


### PR DESCRIPTION
I changed my CLI repo name (kitadai31/rvcli -> kitadai31/revanced-cli)
I thought redirect works
but there is an error report on Revancify support Telegram
So change the repo name in sources.json