### PR TITLE
Small changes to Revancify

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -30,7 +30,7 @@ initialize() {
     header=(dialog --backtitle "Revancify | [Arch: $arch, Root: $root]" --no-shadow)
     envFile=config.cfg
     [ ! -f "apps/.appSize" ] && : > "apps/.appSize"
-    userAgent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
+    userAgent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36"
 
     AutocheckToolsUpdate="" Riplibs="" LightTheme="" ShowConfirmPatchesMenu="" LaunchAppAfterMount="" AllowVersionDowngrade="" FetchPreReleasedTools=""
     setEnv AutocheckToolsUpdate false init "$envFile"

--- a/main.sh
+++ b/main.sh
@@ -595,22 +595,11 @@ downloadMicrog() {
 }
 
 antiSplitApkm() {
-    "${header[@]}" --infobox "Please Wait !!\nReducing app size..." 12 45
-    splits="apps/splits"
-    mkdir "$splits"
-    unzip -qqo "apps/$appName-$appVer.apkm" -d "$splits"
-    rm "apps/$appName-$appVer.apkm"
+    "${header[@]}" --infobox "Please Wait !!\nMerging split apks..." 12 45
     appDir="apps/$appName-$appVer"
-    mkdir "$appDir"
-    cp "$splits/base.apk" "$appDir"
-    cp "$splits/split_config.${arch//-/_}.apk" "$appDir" &> /dev/null
-    locale=$(getprop persist.sys.locale | sed 's/-.*//g')
-    if [ ! -e "$splits/split_config.${locale}.apk" ]; then
-        locale=$(getprop ro.product.locale | sed 's/-.*//g')
-    fi
-    cp "$splits/split_config.${locale}.apk" "$appDir" &> /dev/null
-    cp "$splits"/split_config.*dpi.apk "$appDir" &> /dev/null
-    rm -rf "$splits"
+    mkdir -p "$appDir"
+    unzip -qqo "apps/$appName-$appVer.apkm" -d "$appDir"
+    rm "apps/$appName-$appVer.apkm"
     java -jar ApkEditor.jar m -i "$appDir" -o "apps/$appName-$appVer.apk" &> /dev/null
     rm -rf "$appDir"
     setEnv "${appName//-/_}Size" "$(du -b "apps/$appName-$appVer.apk" | cut -d $'\t' -f 1)" update "apps/.appSize"

--- a/sources.json
+++ b/sources.json
@@ -28,7 +28,7 @@
         {
             "cli":
             {
-                "org": "revanced",
+                "org": "inotia00",
                 "repo": "revanced-cli"
             },
             "patches":


### PR DESCRIPTION
* chore: Update userAgent
* chore: Use revanced extended cli for piko
* fix: Don't reduce split apk
* refactor: Use cp instead of bind mount for rooted installations

All changes tested from my side.

For "fix: Don't reduce split apk" I think it could be better to add option to opt out for it instead of gutted out whole lang detection logic as it's pretty neat, but not sure.
This also fixes merged apk patch failure for current impl.

For "refactor: Use cp instead of bind mount for rooted installations" I use cp instead of hardlink, where prevent some rare cases that hardlink not supported.
By replacing mount to cp, we could avoid mount detection by security apps.

For "chore: Use revanced extended cli for piko", is workaround for issue that prerelease of piko always failed to patch due to official Revanced sided cli prerelease changes.

Finally, for "chore: Update userAgent", is just chore changes that update useragent.
