### PR TITLE
refactor: generalise pkg installation

### DIFF
--- a/revancify
+++ b/revancify
@@ -70,8 +70,8 @@ installDependencies() {
     grep -q unzip <<< "$BINS" || PKGS+=("unzip")
 
     if [ "${#PKGS[@]}" -ne 0 ]; then
-        pkg update -o Dpkg::Options::="--force-confnew" || return 1
-        pkg install "${PKGS[@]}" -y -o Dpkg::Options::="--force-confnew" || return 1
+        pkg update || return 1
+        yes | pkg install "${PKGS[@]}" || return 1
     fi
 
     sed -i '/allow-external-apps/s/# //' "$HOME/.termux/termux.properties"


### PR DESCRIPTION
* Remove -o Dpkg::Options and -y args and use yes to answer install confirmations to make package installation compatible for officially supported bootstraps by Termux (apt, pacman).

Test: Install Revancify on both apt and pacman bootstrap
Change-Id: I9971c38c47d6e6fa6ce7e70f96e61be029623025
