### PR TITLE
Removed RVX-Android-6-7

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -22,13 +22,5 @@
             "json": "https://raw.githubusercontent.com/anddea/revanced-patches/refs/heads/main/patches.json",
             "version": null
         }
-    },
-    {
-        "source": "RVX-Android-6-7",
-        "repository": "kitadai31/revanced-patches-android6-7",
-        "api": {
-            "json": "https://raw.githubusercontent.com/kitadai31/revanced-patches-android6-7/refs/heads/revanced-extended/patches.json",
-            "version": null
-        }
     }
 ]


### PR DESCRIPTION
Sadly Google has killed older versions of YouTube that made RVX-Android-6-7 don't work anymore

I would suggest removing it completely from selecting it